### PR TITLE
Fixed duplicate license file

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -28,4 +28,4 @@ override_dh_installchangelogs:
 
 override_dh_auto_install:
 	dh_auto_install -- PREFIX=/usr
-
+	rm $(CURDIR)/debian/recap/usr/share/doc/recap/COPYING


### PR DESCRIPTION
Lintian warned about having an extra license file (COPYING).
debian/rules modified to delete the upstream GPL-2 license file to avoid
patching the Makefile.

Another way would have been to build with a different make target: install-base vs. install
override_dh_auto_install:
  PREFIX=/usr DESTDIR=${CURDIR}/debian/recap/ $(MAKE) install-base

I chose the first way because I think it's safer in case the Makefile changes in the future.